### PR TITLE
allow pacstrap to skip mount of pseudo filesystems

### DIFF
--- a/pacstrap.in
+++ b/pacstrap.in
@@ -15,6 +15,7 @@ m4_include(common)
 hostcache=0
 copykeyring=1
 copymirrorlist=1
+mountpseudofs=1
 
 usage() {
   cat <<EOF
@@ -27,6 +28,7 @@ usage: ${0##*/} [options] root [packages...]
     -G             Avoid copying the host's pacman keyring to the target
     -i             Avoid auto-confirmation of package selections
     -M             Avoid copying the host's mirrorlist to the target
+    -m             Avoid mounting pseudo filesystems
 
     -h             Print this help message
 
@@ -43,7 +45,7 @@ fi
 
 (( EUID == 0 )) || die 'This script must be run with root privileges'
 
-while getopts ':C:cdGiM' flag; do
+while getopts ':C:cdGiMm' flag; do
   case $flag in
     C)
       pacman_config=$OPTARG
@@ -62,6 +64,8 @@ while getopts ':C:cdGiM' flag; do
       ;;
     M)
       copymirrorlist=0
+    m)
+     mountpseudofs=0
       ;;
     :)
       die '%s: option requires an argument -- '\''%s'\' "${0##*/}" "$OPTARG"
@@ -101,7 +105,9 @@ mkdir -m 1777 -p "$newroot"/tmp
 mkdir -m 0555 -p "$newroot"/{sys,proc}
 
 # mount API filesystems
-chroot_setup "$newroot" || die "failed to setup chroot %s" "$newroot"
+if (( mountpseudofs )); then
+  chroot_setup "$newroot" || die "failed to setup chroot %s" "$newroot"
+fi
 
 msg 'Installing packages to %s' "$newroot"
 if ! pacman -r "$newroot" -Sy "${pacman_args[@]}"; then


### PR DESCRIPTION
It is possible that people embed pacstrap into existing installation
frameworks, such as installimage[0]. Those frameworks may mount all the
needed pseudo filesystems, so pacstrap doesn't need to care about it.
This commit add the -m flag (short for mountfoo). If -m is set, pacstrap
will skip the mount section for pseudofs. The default behaviour is still
to mount them.

[0] https://github.com/virtapi/installimage