### PR TITLE
Hide progressbar if not interactive

### DIFF
--- a/pacstrap.in
+++ b/pacstrap.in
@@ -82,6 +82,7 @@ fi
 
 if (( ! interactive )); then
   pacman_args+=(--noconfirm)
+  pacman_args+=(--noprogressbar)
 fi
 
 if [[ $pacman_config ]]; then


### PR DESCRIPTION
For some automation tasks having the progressbar in the output only makes the log less readable. And because it is not needed in the non interactive session anyway, I'll suggest it being suppressed.